### PR TITLE
chore(Matomo): do not use cookies

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -600,6 +600,7 @@
       var _paq = _paq || [];
       _paq.push(["trackPageView"]);
       _paq.push(["enableLinkTracking"]);
+      _paq.push(['requireCookieConsent']);
       (function () {
         var u = "//piwik.technologiestiftung-berlin.de/";
         _paq.push(["setTrackerUrl", u + "piwik.php"]);


### PR DESCRIPTION
To conform to GDPR requirements, this PR disables the use of cookies by Matomo.

Note that analytics with Matomo will still work, it's just anonymized and without the use of cookies. See [the same implementation in Berlin Open Source](https://github.com/technologiestiftung/berlin-open-source-portal/blob/3f9292eda39c65f8f98face3a73a5c65d4a7b431/src/_includes/layouts/root.liquid#L28) for which analytics in Matomo are still available.

-> [Context](https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/)

---

~~I understand that a push to the main branch will not automatically trigger a new deploy here. But let's make the change here first anyway and then deal with FTP or whatever is necessary.~~ EDIT: Actually, we do have the site deployed to Netlify, so all good.